### PR TITLE
fix: remove duplicate `createRequire` in optimizer

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -813,10 +813,6 @@ async function prepareRolldownOptimizerRun(
       sourcemap: true,
       dir: processingCacheDir,
       entryFileNames: '[name].js',
-      banner:
-        platform === 'node'
-          ? `import { createRequire } from 'module';const require = createRequire(import.meta.url);`
-          : undefined,
     })
     await bundle.close()
     return result


### PR DESCRIPTION
### Description

There is duplicate `createRequire` in `playground/ssr-deps/node_modules/.vite/deps_ssr/chunk-B6b7aAQJ.js` due to Rolldown's automatic polyfill and Vite's banner.

```js
import { createRequire } from 'module';const require = createRequire(import.meta.url);
import { createRequire } from "module";

//#region rolldown:runtime
var __getOwnPropNames = Object.getOwnPropertyNames;
var __commonJS = (cb, mod) => function() {
	return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
};
var __require = /* @__PURE__ */ createRequire(import.meta.url);

//#endregion
export { __commonJS, __require };
```

Current Vite SSR is tolerating this code https://github.com/vitejs/vite/issues/19617, but this gets surfaced when oxc transform rejected this code https://github.com/vitejs/rolldown-vite/pull/85.

I think the banner is redundant now, so just removing it seems fix it.
