### PR TITLE
fix: use exact regexp filter for virtual module

### DIFF
--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -12,8 +12,6 @@ export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:modulepreload-polyfill',
     resolveId: {
-      // TODO: string filter breaks on wasi, so use exact regex for now
-      // https://github.com/rolldown/rolldown/issues/3964
       filter: { id: exactRegex(modulePreloadPolyfillId) },
       handler(_id) {
         return resolvedModulePreloadPolyfillId

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -1,5 +1,6 @@
 import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
+import { exactRegex } from '../utils'
 import { isModernFlag } from './importAnalysisBuild'
 
 export const modulePreloadPolyfillId = 'vite/modulepreload-polyfill'
@@ -11,13 +12,15 @@ export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:modulepreload-polyfill',
     resolveId: {
-      filter: { id: modulePreloadPolyfillId },
+      // TODO: string filter breaks on wasi, so use exact regex for now
+      // https://github.com/rolldown/rolldown/issues/3964
+      filter: { id: exactRegex(modulePreloadPolyfillId) },
       handler(_id) {
         return resolvedModulePreloadPolyfillId
       },
     },
     load: {
-      filter: { id: resolvedModulePreloadPolyfillId },
+      filter: { id: exactRegex(resolvedModulePreloadPolyfillId) },
       handler(_id) {
         // `isModernFlag` is only available during build since it is resolved by `vite:build-import-analysis`
         if (

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from '../plugin'
+import { exactRegex } from '../utils'
 import { fileToUrl } from './asset'
 
 const wasmHelperId = '\0vite/wasm-helper.js'
@@ -51,14 +52,14 @@ export const wasmHelperPlugin = (): Plugin => {
     name: 'vite:wasm-helper',
 
     resolveId: {
-      filter: { id: wasmHelperId },
+      filter: { id: exactRegex(wasmHelperId) },
       handler(id) {
         return id
       },
     },
 
     load: {
-      filter: { id: [wasmHelperId, /\.wasm\?init$/] },
+      filter: { id: [exactRegex(wasmHelperId), /\.wasm\?init$/] },
       async handler(id) {
         if (id === wasmHelperId) {
           return `export default ${wasmHelperCode}`

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1517,6 +1517,10 @@ export function escapeRegex(str: string): string {
   return str.replace(escapeRegexRE, '\\$&')
 }
 
+export function exactRegex(str: string): RegExp {
+  return new RegExp(`^${escapeRegex(str)}$`)
+}
+
 type CommandType = 'install' | 'uninstall' | 'update'
 export function getPackageManagerCommand(
   type: CommandType = 'install',


### PR DESCRIPTION
### Description

Related https://github.com/rolldown/rolldown/issues/3964, https://github.com/rolldown/rolldown/issues/3970

~Probably we shouldn't need to do this, but I'm not sure a way forward, so I think we can use exact regex for the time being.~  see discussion in https://github.com/rolldown/rolldown/pull/3972

Also I wanted to see if this is enough to make build pass on stackblitz and it looks like working now https://stackblitz.com/edit/vitejs-vite-8n2i1q5j?file=package.json&terminal=build