### PR TITLE
fix(transform): merge tsconfig jsx options with oxc jsx options correctly

### DIFF
--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -91,7 +91,11 @@ export async function transformWithOxc(
 
       // when both the normal options and tsconfig is set,
       // we want to prioritize the normal options
-      if (resolvedOptions.jsx === undefined) {
+      if (
+        resolvedOptions.jsx === undefined ||
+        (typeof resolvedOptions.jsx === 'object' &&
+          resolvedOptions.jsx.runtime === undefined)
+      ) {
         if (loadedCompilerOptions.jsx === 'preserve') {
           resolvedOptions.jsx = 'preserve'
         } else {

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -99,16 +99,16 @@ export async function transformWithOxc(
         if (loadedCompilerOptions.jsx === 'preserve') {
           resolvedOptions.jsx = 'preserve'
         } else {
-          const jsxOptions: OxcJsxOptions = {}
+          const jsxOptions: OxcJsxOptions = { ...resolvedOptions.jsx }
 
           if (loadedCompilerOptions.jsxFactory) {
-            jsxOptions.pragma = loadedCompilerOptions.jsxFactory
+            jsxOptions.pragma ??= loadedCompilerOptions.jsxFactory
           }
           if (loadedCompilerOptions.jsxFragmentFactory) {
-            jsxOptions.pragmaFrag = loadedCompilerOptions.jsxFragmentFactory
+            jsxOptions.pragmaFrag ??= loadedCompilerOptions.jsxFragmentFactory
           }
           if (loadedCompilerOptions.jsxImportSource) {
-            jsxOptions.importSource = loadedCompilerOptions.jsxImportSource
+            jsxOptions.importSource ??= loadedCompilerOptions.jsxImportSource
           }
 
           switch (loadedCompilerOptions.jsx) {


### PR DESCRIPTION
### Description

Merge jsx options in tsconfig even if `oxc: { development: true }` is set (this is the default).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
