### PR TITLE
fix(optimizer): derive `resolve.symlinks` option properly

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1103,7 +1103,13 @@ function resolveDepOptimizationOptions(
         }
       }
     }
-    setResolveOptions('symlinks', optimizeDeps.esbuildOptions.preserveSymlinks)
+    if (
+      optimizeDeps.esbuildOptions.preserveSymlinks !== undefined &&
+      optimizeDeps.rollupOptions.resolve.symlinks === undefined
+    ) {
+      optimizeDeps.rollupOptions.resolve.symlinks =
+        !optimizeDeps.esbuildOptions.preserveSymlinks
+    }
     setResolveOptions(
       'extensions',
       optimizeDeps.esbuildOptions.resolveExtensions,
@@ -1169,6 +1175,11 @@ function resolveDepOptimizationOptions(
       noDiscovery: consumer !== 'client',
       esbuildOptions: {
         preserveSymlinks,
+      },
+      rollupOptions: {
+        resolve: {
+          symlinks: !preserveSymlinks,
+        },
       },
       force: forceOptimizeDeps ?? configDefaults.optimizeDeps.force,
     },


### PR DESCRIPTION
### Description

When the top-level `resolve.preserveSymlinks` is set, derive it to `optimizeDeps.rollupOptions.resolve.symlinks`.

This fixes the ecosystem-ci with storybook.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
