### PR TITLE
fix(worker): suppress export related warnings in worker build

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -101,6 +101,14 @@ async function bundleWorkerEntry(
       injectEnvironmentToHooks(workerEnvironment, chunkMetadataMap, p),
     ),
     onLog(level, log) {
+      if (
+        log.code === 'MIXED_EXPORT' ||
+        log.code === 'MISSING_NAME_OPTION_FOR_IIFE_EXPORT'
+      ) {
+        // these warning will be output because `preserveEntrySignatures` is not supported by rolldown
+        // suppress these warnings as users do not need to care about it
+        return
+      }
       onRollupLog(level, log, workerEnvironment)
     },
     // TODO: remove this and enable rolldown's CSS support later


### PR DESCRIPTION
### Description

Suppress export related warnings in worker build as these will be output because `preserveEntrySignatures` is not supported by rolldown. 

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
