### PR TITLE
perf: define viteMetadata instead of assign

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1359,7 +1359,11 @@ function injectChunkMetadata(
       __modules: chunk.modules,
     })
   }
-  chunk.viteMetadata = chunkMetadataMap.get(key)
+  // define instead of assign to avoid detected as a change
+  // https://github.com/rolldown/rolldown/blob/f4c5ff27799f2b0152c689c398e61bc7d30429ff/packages/rolldown/src/utils/transform-to-rollup-output.ts#L87
+  Object.defineProperty(chunk, 'viteMetadata', {
+    value: chunkMetadataMap.get(key),
+  })
   Object.defineProperty(chunk, 'modules', {
     get() {
       return chunk.viteMetadata!.__modules


### PR DESCRIPTION
### Description

If this is done by an assignment, it gets detected on the rolldown side and rolldown tries to sync.
https://github.com/rolldown/rolldown/blob/f4c5ff27799f2b0152c689c398e61bc7d30429ff/packages/rolldown/src/utils/transform-to-rollup-output.ts#L87
This is not needed and has a big overhead especially when sourcemaps are enabled.

To avoid that from happening, I replaced the assignment with `Object.defineProperty` (this does not trigger the setter).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
