### PR TITLE
fix(optimizer): include rollupOptions in config hash

### DIFF
--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -20,6 +20,7 @@ export function getDefaultResolvedEnvironmentOptions(
     optimizeDeps: config.optimizeDeps,
     dev: config.dev,
     build: config.build,
+    optimizeDepsPluginNames: [],
   }
 }
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1237,11 +1237,19 @@ function getConfigHash(environment: Environment): string {
         exclude: optimizeDeps.exclude
           ? unique(optimizeDeps.exclude).sort()
           : undefined,
-        esbuildOptions: {
-          ...optimizeDeps.esbuildOptions,
-          plugins: optimizeDeps.esbuildOptions?.plugins?.map((p) => p.name),
+        rollupOptions: {
+          ...optimizeDeps.rollupOptions,
+          plugins: undefined, // included in optimizeDepsPluginNames
+          onLog: undefined,
+          onwarn: undefined,
+          checks: undefined,
+          output: {
+            ...optimizeDeps.rollupOptions?.output,
+            plugins: undefined, // included in optimizeDepsPluginNames
+          },
         },
       },
+      optimizeDepsPluginNames: config.optimizeDepsPluginNames,
     },
     (_, value) => {
       if (typeof value === 'function' || value instanceof RegExp) {

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -104,7 +104,9 @@ export async function resolvePlugins(
             optimizeDeps: true,
             externalize: true,
           },
-          isWorker ? { ...config, consumer: 'client' } : undefined,
+          isWorker
+            ? { ...config, consumer: 'client', optimizeDepsPluginNames: [] }
+            : undefined,
         )
       : [
           resolvePlugin({


### PR DESCRIPTION
### Description

config hash should now include rollupOptions instead of esbuildOptions.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
