### PR TITLE
feat: add backward compat and warning for esbuild.banner/footer

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1645,7 +1645,7 @@ export async function resolveConfig(
         ),
       )
     } else {
-      oxc = convertEsbuildConfigToOxcConfig(config.esbuild)
+      oxc = convertEsbuildConfigToOxcConfig(config.esbuild, logger)
     }
   }
 

--- a/packages/vite/src/node/plugins/esbuildBannerFooterCompatPlugin.ts
+++ b/packages/vite/src/node/plugins/esbuildBannerFooterCompatPlugin.ts
@@ -1,0 +1,61 @@
+import MagicString from 'magic-string'
+import type { Plugin } from '../plugin'
+import type { ResolvedConfig } from '../config'
+import { createFilter } from '../utils'
+import { cleanUrl } from '../../shared/utils'
+
+/**
+ * This plugin supports `esbuild.banner` and `esbuild.footer` options.
+ * esbuild supported these options and Vite exposed them.
+ * But this should be done by plugin with transform hook.
+ * This plugin makes these options work in rolldown-vite as a backward compat for now.
+ */
+export function esbuildBannerFooterCompatPlugin(
+  config: ResolvedConfig,
+): Plugin | undefined {
+  const options = config.esbuild
+  if (!options) return
+
+  const { include, exclude, banner, footer } = options
+  if (!banner && !footer) return
+
+  const filter = createFilter(include || /\.(m?ts|[jt]sx)$/, exclude || /\.js$/)
+
+  return {
+    name: 'vite:esbuild-banner-footer-compat',
+    transform(code, id) {
+      if (filter(id) || filter(cleanUrl(id))) {
+        const needsSourcemap =
+          this.environment.mode === 'dev' ||
+          (this.environment.mode === 'build' &&
+            this.environment.config.build.sourcemap)
+        if (!needsSourcemap) {
+          if (banner) {
+            code = `${banner}\n${code}`
+          }
+          if (footer) {
+            code = `${code}\n${footer}`
+          }
+          return code
+        }
+
+        let s: MagicString | undefined
+        const str = () => s || (s = new MagicString(code))
+
+        if (banner) {
+          str().prepend(`${banner}\n`)
+        }
+        if (footer) {
+          str().append(`${footer}\n`)
+        }
+
+        if (s) {
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: 'boundary' }),
+          }
+        }
+      }
+    },
+  }
+}

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -42,6 +42,7 @@ import {
   createIdFilter,
 } from './pluginFilter'
 import { oxcPlugin } from './oxc'
+import { esbuildBannerFooterCompatPlugin } from './esbuildBannerFooterCompatPlugin'
 
 export async function resolvePlugins(
   config: ResolvedConfig,
@@ -121,6 +122,7 @@ export async function resolvePlugins(
         ]),
     htmlInlineProxyPlugin(config),
     cssPlugin(config),
+    esbuildBannerFooterCompatPlugin(config),
     config.oxc !== false
       ? enableNativePlugin === true
         ? nativeTransformPlugin()

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -10,6 +10,7 @@ import type { InternalModuleFormat, RollupError, SourceMap } from 'rolldown'
 import { rolldown } from 'rolldown'
 import type { FSWatcher } from 'dep-types/chokidar'
 import { TSConfckParseError } from 'tsconfck'
+import colors from 'picocolors'
 import {
   combineSourcemaps,
   createFilter,
@@ -23,6 +24,7 @@ import { cleanUrl } from '../../shared/utils'
 import type { Environment } from '..'
 import type { ViteDevServer } from '../server'
 import { JS_TYPES_RE } from '../constants'
+import type { Logger } from '../logger'
 import type { ESBuildOptions } from './esbuild'
 import { loadTsconfigJsonForFile } from './esbuild'
 
@@ -564,6 +566,7 @@ type OxcJsxOptions = Exclude<OxcOptions['jsx'], string | undefined>
 
 export function convertEsbuildConfigToOxcConfig(
   esbuildConfig: ESBuildOptions,
+  logger: Logger,
 ): OxcOptions {
   const { jsxInject, include, exclude, ...esbuildTransformOptions } =
     esbuildConfig
@@ -610,5 +613,26 @@ export function convertEsbuildConfigToOxcConfig(
     oxcOptions.define = esbuildTransformOptions.define
   }
 
+  // these backward compat are supported by esbuildBannerFooterCompatPlugin
+  if (esbuildTransformOptions.banner) {
+    warnDeprecatedShouldBeConvertedToPluginOptions(logger, 'banner')
+  }
+  if (esbuildTransformOptions.footer) {
+    warnDeprecatedShouldBeConvertedToPluginOptions(logger, 'footer')
+  }
+
   return oxcOptions
+}
+
+function warnDeprecatedShouldBeConvertedToPluginOptions(
+  logger: Logger,
+  name: string,
+) {
+  logger.warn(
+    colors.yellow(
+      `\`esbuild.${name}\` option was specified. ` +
+        `But this option is deprecated and will be removed in future versions. ` +
+        'This option can be achieved by using a plugin with transform hook, please use that instead.',
+    ),
+  )
 }


### PR DESCRIPTION
### Description

`esbuild.banner`/`esbuild.footer` option was not supposed to be used.
But it was used in some cases ([code search](https://github.com/search?q=%2Fesbuild%3A%2F+%2Fbanner%3A%2F+language%3ATypeScript&type=code&p=1&l=TypeScript)) and in [`vite-plugin-node-polyfills`](https://github.com/davidmyersdev/vite-plugin-node-polyfills/blob/8d68d4f49724cc650752dcecdf4062aae30095d6/src/index.ts#L230-L231).
This PR adds a backward compat plugin for that and also adds a deprecation warning for it.

close #134

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
