### PR TITLE
chore: add rolldown-vite indicator

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -572,7 +572,7 @@ async function buildEnvironment(
 
   logger.info(
     colors.cyan(
-      `vite v${VERSION} ${colors.green(
+      `rolldown-vite v${VERSION} ${colors.green(
         `building ${ssr ? `SSR bundle ` : ``}for ${environment.config.mode}...`,
       )}`,
     ),

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -218,7 +218,7 @@ cli
 
       info(
         `\n  ${colors.green(
-          `${colors.bold('VITE')} v${VERSION}`,
+          `${colors.bold('ROLLDOWN-VITE')} v${VERSION}`,
         )}${modeString}  ${startupDurationString}\n`,
         {
           clear: !hasExistingLogs,


### PR DESCRIPTION
Make sure people are aware that `rolldown-vite` is running by changing the console output from "vite" to "rolldown-vite"

We can also do "Vite (with Rolldown)" but I felt it is a bit too lengthy.