### PR TITLE
feat(types): make exposed `Rollup` type more compatible with Rollup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,6 +98,7 @@ export default tseslint.config(
           allowModules: [
             'vite',
             'esbuild',
+            'rolldown',
             'less',
             'sass',
             'sass-embedded',

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -1,6 +1,7 @@
-import type * as Rollup from 'rolldown'
+import type * as Rolldown from 'rolldown'
+import type * as Rollup from 'types/internal/rollupTypeCompat'
 
-export type { Rollup }
+export type { Rollup, Rolldown }
 export { parseAst, parseAstAsync } from 'rolldown/parseAst'
 export {
   defineConfig,

--- a/packages/vite/types/internal/rollupTypeCompat.d.ts
+++ b/packages/vite/types/internal/rollupTypeCompat.d.ts
@@ -1,0 +1,21 @@
+import type * as Rolldown from 'rolldown'
+
+export * from 'rolldown'
+
+/** @deprecated use RolldownBuild instead */
+export type RollupBuild = Rolldown.RolldownBuild
+
+/** @deprecated use RolldownOptions instead */
+export type RollupOptions = Rolldown.RolldownOptions
+
+/** @deprecated use RolldownOutput instead */
+export type RollupOutput = Rolldown.RolldownOutput
+
+/** @deprecated use RolldownPlugin instead */
+export type RollupPlugin = Rolldown.RolldownPlugin
+
+/** @deprecated use RolldownPluginOption instead */
+export type RollupPluginOption = Rolldown.RolldownPluginOption
+
+/** @deprecated use RolldownWatcher instead */
+export type RollupWatcher = Rolldown.RolldownWatcher


### PR DESCRIPTION
### Description

Add some `Rollup*` types to `Rollup` type exposed from Vite so that the migration is easier.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
