### PR TITLE
feat: enable all native plugins by default

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import { rolldown } from 'rolldown'
 import { definePlugin } from '../../plugins/define'
 import { resolveConfig } from '../../config'
 import { PartialEnvironment } from '../../baseEnvironment'
@@ -16,17 +17,48 @@ async function createDefinePluginTransform(
   const environment = new PartialEnvironment(ssr ? 'ssr' : 'client', config)
 
   return async (code: string) => {
-    // @ts-expect-error transform.handler should exist
-    const result = await instance.transform.handler.call(
-      { environment },
-      code,
-      'foo.ts',
-    )
-    return result?.code || result
+    if (process.env._VITE_TEST_JS_PLUGIN) {
+      // @ts-expect-error transform.handler should exist
+      const result = await instance.transform.handler.call(
+        { environment },
+        code,
+        'foo.ts',
+      )
+      return result?.code || result
+    } else {
+      const bundler = await rolldown({
+        input: 'entry.js',
+        plugins: [
+          {
+            name: 'test',
+            resolveId(id) {
+              if (id === 'entry.js') {
+                return '\0' + id
+              }
+            },
+            load(id) {
+              if (id === '\0entry.js') {
+                return code
+              }
+            },
+          },
+          {
+            name: 'native:define',
+            options: (definePlugin(config).options! as any).bind({
+              environment,
+            }),
+          },
+        ],
+        experimental: {
+          attachDebugInfo: 'none',
+        },
+      })
+      return (await bundler.generate()).output[0].code
+    }
   }
 }
 
-describe('definePlugin', () => {
+describe.skipIf(!process.env._VITE_TEST_JS_PLUGIN)('definePlugin', () => {
   test('replaces custom define', async () => {
     const transform = await createDefinePluginTransform({
       __APP_VERSION__: JSON.stringify('1.0'),
@@ -143,6 +175,123 @@ describe('definePlugin', () => {
       ),
     ).toMatch(
       /const __vite_import_meta_env__1 = .*;\nconsole.log\(__vite_import_meta_env__\);\nexport const env = __vite_import_meta_env__1;\nconsole.log\(undefined {26}\);/,
+    )
+  })
+})
+
+describe.skipIf(process.env._VITE_TEST_JS_PLUGIN)('native definePlugin', () => {
+  test('replaces custom define', async () => {
+    const transform = await createDefinePluginTransform({
+      __APP_VERSION__: JSON.stringify('1.0'),
+    })
+    expect(await transform('export const version = __APP_VERSION__;')).toBe(
+      'const version = "1.0";\n\nexport { version };',
+    )
+    expect(await transform('export const version = __APP_VERSION__ ;')).toBe(
+      'const version = "1.0";\n\nexport { version };',
+    )
+  })
+
+  test('should not replace if not defined', async () => {
+    const transform = await createDefinePluginTransform({
+      __APP_VERSION__: JSON.stringify('1.0'),
+    })
+    expect(await transform('export const version = "1.0";')).toBe(
+      'const version = "1.0";\n\nexport { version };',
+    )
+    expect(
+      await transform('export const version = import.meta.SOMETHING'),
+    ).toBe('const version = import.meta.SOMETHING;\n\nexport { version };')
+  })
+
+  test('replaces import.meta.env.SSR with false', async () => {
+    const transform = await createDefinePluginTransform()
+    expect(await transform('export const isSSR = import.meta.env.SSR;')).toBe(
+      'const isSSR = false;\n\nexport { isSSR };',
+    )
+  })
+
+  test('preserve import.meta.hot with override', async () => {
+    // assert that the default behavior is to replace import.meta.hot with undefined
+    const transform = await createDefinePluginTransform()
+    expect(await transform('export const hot = import.meta.hot;')).toBe(
+      'const hot = void 0;\n\nexport { hot };',
+    )
+    // assert that we can specify a user define to preserve import.meta.hot
+    const overrideTransform = await createDefinePluginTransform({
+      'import.meta.hot': 'import.meta.hot',
+    })
+    expect(await overrideTransform('export const hot = import.meta.hot;')).toBe(
+      'const hot = import.meta.hot;\n\nexport { hot };',
+    )
+  })
+
+  test('replace import.meta.env.UNKNOWN with undefined', async () => {
+    const transform = await createDefinePluginTransform()
+    expect(await transform('export const foo = import.meta.env.UNKNOWN;')).toBe(
+      'const foo = void 0;\n\nexport { foo };',
+    )
+  })
+
+  test('leave import.meta.env["UNKNOWN"] to runtime', async () => {
+    const transform = await createDefinePluginTransform()
+    expect(
+      await transform('export const foo = import.meta.env["UNKNOWN"];'),
+    ).toMatch(/const foo = .*\["UNKNOWN"\];\n\nexport \{ foo \};/s)
+  })
+
+  test('preserve import.meta.env.UNKNOWN with override', async () => {
+    const transform = await createDefinePluginTransform({
+      'import.meta.env.UNKNOWN': 'import.meta.env.UNKNOWN',
+    })
+    expect(await transform('export const foo = import.meta.env.UNKNOWN;')).toBe(
+      'const foo = import.meta.env.UNKNOWN;\n\nexport { foo };',
+    )
+  })
+
+  test('replace import.meta.env when it is a invalid json', async () => {
+    const transform = await createDefinePluginTransform({
+      'import.meta.env.LEGACY': '__VITE_IS_LEGACY__',
+    })
+
+    expect(
+      await transform(
+        'export const isLegacy = import.meta.env.LEGACY;\nimport.meta.env.UNDEFINED && console.log(import.meta.env.UNDEFINED);',
+      ),
+    ).toMatchInlineSnapshot(
+      `"const isLegacy = __VITE_IS_LEGACY__;\n\nexport { isLegacy };"`,
+    )
+  })
+
+  test('replace bare import.meta.env', async () => {
+    const transform = await createDefinePluginTransform()
+    expect(await transform('export const env = import.meta.env;')).toMatch(
+      /const env = .*;\n\nexport \{ env \};/s,
+    )
+  })
+
+  test('already has marker', async () => {
+    const transform = await createDefinePluginTransform()
+    expect(
+      await transform(
+        'console.log(__vite_import_meta_env__);\nexport const env = import.meta.env;',
+      ),
+    ).toMatch(/console.log\(__vite_import_meta_env__\);\nconst env = .*/)
+
+    expect(
+      await transform(
+        'console.log(__vite_import_meta_env__, __vite_import_meta_env__1);\n export const env = import.meta.env;',
+      ),
+    ).toMatch(
+      /console.log\(__vite_import_meta_env__, __vite_import_meta_env__1\);\nconst env = .*/,
+    )
+
+    expect(
+      await transform(
+        'console.log(__vite_import_meta_env__);\nexport const env = import.meta.env;\nconsole.log(import.meta.env.UNDEFINED);',
+      ),
+    ).toMatch(
+      /console.log\(__vite_import_meta_env__\);\nconst env = .*;\nconsole.log\(void 0\);/s,
     )
   })
 })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -505,14 +505,14 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
     ],
     post: [
       ...buildImportAnalysisPlugin(config),
-      ...(config.experimental.enableNativePlugin !== true
-        ? [
+      ...(config.nativePluginEnabledLevel >= 1
+        ? []
+        : [
             buildOxcPlugin(),
             ...(config.build.minify === 'esbuild'
               ? [buildEsbuildPlugin()]
               : []),
-          ]
-        : []),
+          ]),
       terserPlugin(config),
       ...(!config.isWorker
         ? [

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1893,7 +1893,6 @@ export async function resolveConfig(
     ),
     [SYMBOL_RESOLVED_CONFIG]: true,
   }
-
   resolved = {
     ...config,
     ...resolved,

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -115,7 +115,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     return pattern
   }
 
-  if (config.experimental.enableNativePlugin === true && isBuild) {
+  if (isBuild && config.nativePluginEnabledLevel >= 1) {
     return {
       name: 'vite:define',
       options(option) {

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -173,10 +173,7 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
     extensions: [],
   })
 
-  if (
-    config.experimental.enableNativePlugin === true &&
-    config.command === 'build'
-  ) {
+  if (config.command === 'build' && config.nativePluginEnabledLevel >= 1) {
     return perEnvironmentPlugin('native:dynamic-import-vars', (environment) => {
       const { include, exclude } =
         environment.config.build.dynamicImportVarsOptions

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -749,7 +749,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
     },
   }
 
-  if (config.experimental.enableNativePlugin === true) {
+  if (config.nativePluginEnabledLevel >= 1) {
     delete plugin.transform
     delete plugin.resolveId
     delete plugin.load

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -42,10 +42,7 @@ interface ParsedGeneralImportGlobOptions extends GeneralImportGlobOptions {
 }
 
 export function importGlobPlugin(config: ResolvedConfig): Plugin {
-  if (
-    config.experimental.enableNativePlugin === true &&
-    config.command === 'build'
-  ) {
+  if (config.command === 'build' && config.nativePluginEnabledLevel >= 1) {
     return nativeImportGlobPlugin({
       root: config.root,
       restoreQueryExtension: config.experimental.importGlobRestoreExtension,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -46,14 +46,15 @@ export async function resolvePlugins(
     ? await (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
   const { modulePreload } = config.build
-  const enableNativePlugin = config.experimental.enableNativePlugin
+  const enableNativePlugin = config.nativePluginEnabledLevel >= 0
+  const enableNativePluginV1 = config.nativePluginEnabledLevel >= 1
 
   return [
     !isBuild ? optimizedDepsPlugin() : null,
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     !isBuild ? preAliasPlugin(config) : null,
-    enableNativePlugin === true &&
     isBuild &&
+    enableNativePluginV1 &&
     !config.resolve.alias.some((v) => v.customResolver)
       ? nativeAliasPlugin({
           entries: config.resolve.alias.map((item) => {
@@ -104,7 +105,7 @@ export async function resolvePlugins(
     cssPlugin(config),
     esbuildBannerFooterCompatPlugin(config),
     config.oxc !== false ? oxcPlugin(config) : null,
-    jsonPlugin(config.json, isBuild, enableNativePlugin === true),
+    jsonPlugin(config.json, isBuild, enableNativePluginV1),
     wasmHelperPlugin(config),
     webWorkerPlugin(config),
     assetPlugin(config),

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -35,10 +35,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
       },
     }
   })
-  if (
-    config.build.manifest &&
-    config.experimental.enableNativePlugin === true
-  ) {
+  if (config.build.manifest && config.nativePluginEnabledLevel >= 1) {
     return perEnvironmentPlugin('native:manifest', (environment) => {
       if (!environment.config.build.manifest) return false
 

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -8,10 +8,7 @@ export const modulePreloadPolyfillId = 'vite/modulepreload-polyfill'
 const resolvedModulePreloadPolyfillId = '\0' + modulePreloadPolyfillId + '.js'
 
 export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
-  if (
-    config.experimental.enableNativePlugin === true &&
-    config.command === 'build'
-  ) {
+  if (config.command === 'build' && config.nativePluginEnabledLevel >= 1) {
     return perEnvironmentPlugin(
       'native:modulepreload-polyfill',
       (environment) => {

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -277,10 +277,7 @@ function resolveTsconfigTarget(target: string | undefined): number | 'next' {
 }
 
 export function oxcPlugin(config: ResolvedConfig): Plugin {
-  if (
-    config.experimental.enableNativePlugin === true &&
-    config.command === 'build'
-  ) {
+  if (config.command === 'build' && config.nativePluginEnabledLevel >= 1) {
     return perEnvironmentPlugin('native:transform', (environment) => {
       const {
         jsxInject,

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -28,7 +28,7 @@ type LogEntry = {
 const COMPRESSIBLE_ASSETS_RE = /\.(?:html|json|svg|txt|xml|xhtml|wasm)$/
 
 export function buildReporterPlugin(config: ResolvedConfig): Plugin {
-  if (config.experimental.enableNativePlugin === true) {
+  if (config.nativePluginEnabledLevel >= 1) {
     return perEnvironmentPlugin('native:reporter', (env) => {
       const tty = process.stdout.isTTY && !process.env.CI
       const shouldLogInfo =

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -54,10 +54,7 @@ const wasmHelper = async (opts = {}, url: string) => {
 const wasmHelperCode = wasmHelper.toString()
 
 export const wasmHelperPlugin = (config: ResolvedConfig): Plugin => {
-  if (
-    config.experimental.enableNativePlugin === true &&
-    config.command === 'build'
-  ) {
+  if (config.command === 'build' && config.nativePluginEnabledLevel >= 1) {
     return nativeWasmHelperPlugin({
       decodedBase: config.decodedBase,
     })
@@ -92,7 +89,10 @@ export const wasmHelperPlugin = (config: ResolvedConfig): Plugin => {
 }
 
 export const wasmFallbackPlugin = (config: ResolvedConfig): Plugin => {
-  if (config.experimental.enableNativePlugin === true) {
+  if (
+    config.experimental.enableNativePlugin === true ||
+    config.experimental.enableNativePlugin === 'v1'
+  ) {
     return nativeWasmFallbackPlugin()
   }
 

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -89,10 +89,7 @@ export const wasmHelperPlugin = (config: ResolvedConfig): Plugin => {
 }
 
 export const wasmFallbackPlugin = (config: ResolvedConfig): Plugin => {
-  if (
-    config.experimental.enableNativePlugin === true ||
-    config.experimental.enableNativePlugin === 'v1'
-  ) {
+  if (config.nativePluginEnabledLevel >= 1) {
     return nativeWasmFallbackPlugin()
   }
 

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -234,10 +234,7 @@ export async function workerFileToUrl(
 }
 
 export function webWorkerPostPlugin(config: ResolvedConfig): Plugin {
-  if (
-    config.experimental.enableNativePlugin === true &&
-    config.command === 'build'
-  ) {
+  if (config.command === 'build' && config.nativePluginEnabledLevel >= 1) {
     return perEnvironmentPlugin(
       'native:web-worker-post-plugin',
       (environment) => {

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -88,12 +88,15 @@ const baseRawResult = {
 }
 
 test('should work', async () => {
-  await expect
-    .poll(async () => JSON.parse(await page.textContent('.result')))
-    .toStrictEqual(allResult)
-  await expect
-    .poll(async () => JSON.parse(await page.textContent('.result-eager')))
-    .toStrictEqual(allResult)
+  // TODO: extglobs are not supported yet: https://github.com/vitejs/rolldown-vite/issues/365
+  if (process.env._VITE_TEST_JS_PLUGIN) {
+    await expect
+      .poll(async () => JSON.parse(await page.textContent('.result')))
+      .toStrictEqual(allResult)
+    await expect
+      .poll(async () => JSON.parse(await page.textContent('.result-eager')))
+      .toStrictEqual(allResult)
+  }
   await expect
     .poll(async () =>
       JSON.parse(await page.textContent('.result-node_modules')),

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -140,11 +140,11 @@ describe.runIf(isBuild)('build tests', () => {
 
   test('sourcemap is correct when preload information is injected', async () => {
     const map = findAssetFile(/after-preload-dynamic-[-\w]{8}\.js\.map/)
-    expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
+    let mapSnapshot = `
       {
         "debugId": "00000000-0000-0000-0000-000000000000",
         "ignoreList": [],
-        "mappings": ";grCAAA,OAAO,6BAAuB,wBAE9B,QAAQ,IAAI,wBAAuB",
+        "mappings": ";grCAAA,OAAO,qDAEP,QAAQ,IAAI,wBAAwB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],
@@ -156,7 +156,16 @@ describe.runIf(isBuild)('build tests', () => {
         ],
         "version": 3,
       }
-    `)
+    `
+    if (process.env._VITE_TEST_JS_PLUGIN) {
+      mapSnapshot = mapSnapshot.replace(
+        ';grCAAA,OAAO,qDAEP,QAAQ,IAAI,wBAAwB',
+        ';grCAAA,OAAO,6BAAuB,wBAE9B,QAAQ,IAAI,wBAAuB',
+      )
+    }
+    expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(
+      mapSnapshot,
+    )
     // verify sourcemap comment is preserved at the last line
     const js = findAssetFile(/after-preload-dynamic-[-\w]{8}\.js$/)
     expect(js).toMatch(

--- a/playground/minify/vite.config.js
+++ b/playground/minify/vite.config.js
@@ -8,5 +8,10 @@ export default defineConfig({
   build: {
     minify: 'esbuild',
     cssMinify: 'esbuild',
+    rollupOptions: {
+      output: {
+        legalComments: 'none',
+      },
+    },
   },
 })


### PR DESCRIPTION
### Description

This PR enables the current stable native plugins. The default value of `experimental.enableNativePlugin` is changed from `'resolver'` to `'v1'`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
