### PR TITLE
fix(css): inject CSS correctly when `cssCodesplit: true` and IIFE/UMD

### DIFF
--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -30,10 +30,11 @@ import type { ESBuildOptions } from './esbuild'
 import { loadTsconfigJsonForFile } from './esbuild'
 
 // IIFE content looks like `var MyLib = (function() {`.
-const IIFE_BEGIN_RE =
+export const IIFE_BEGIN_RE =
   /(?:(?:const|var)\s+\S+\s*=\s*|^|\n)\(?function\([^()]*\)\s*\{(?:\s*"use strict";)?/
 // UMD content looks like `(this, function(exports) {`.
-const UMD_BEGIN_RE = /\(this,\s*function\([^()]*\)\s*\{(?:\s*"use strict";)?/
+export const UMD_BEGIN_RE =
+  /\(this,\s*function\([^()]*\)\s*\{(?:\s*"use strict";)?/
 
 const jsxExtensionsRE = /\.(?:j|t)sx\b/
 const validExtensionRE = /\.\w+$/


### PR DESCRIPTION
### Description

This change is now needed because rolldown does not inject `"use strict"` sometimes. (rollup always injects it)

https://github.com/vitejs/vite-plugin-vue/blob/6737f06884db49cbeb59da8b63a3dae9d209b789/playground/vue-lib/__tests__/vue-lib.spec.ts#L26-L35 covers this behavior.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
