### PR TITLE
test: `onTestFinished` instead of `afterEach` for file restoration

### DIFF
--- a/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect } from 'vitest'
 import type { ViteDevServer } from '../../..'
-import { createModuleRunnerTester, editFile, resolvePath } from './utils'
+import {
+  createFixtureEditor,
+  createModuleRunnerTester,
+  resolvePath,
+} from './utils'
 
 describe('module runner initialization', async () => {
   const it = await createModuleRunnerTester(
@@ -47,8 +51,10 @@ describe('module runner initialization', async () => {
       '    at Module.throwError (<root>/fixtures/throws-error-method.ts:6:9)',
     )
 
+    const fixtureEditor = createFixtureEditor()
+
     // simulate HMR
-    editFile(
+    fixtureEditor.editFile(
       resolvePath(import.meta.url, './fixtures/throws-error-method.ts'),
       (code) => '\n\n\n\n\n' + code + '\n',
     )

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { TestAPI } from 'vitest'
-import { afterEach, beforeEach, test } from 'vitest'
+import { afterEach, beforeEach, onTestFinished, test } from 'vitest'
 import type { ModuleRunner } from 'vite/module-runner'
 import type { ServerModuleRunnerOptions } from '../serverModuleRunner'
 import type { ViteDevServer } from '../../../server'
@@ -103,34 +103,26 @@ export async function createModuleRunnerTester(
   return test as TestAPI<TestClient>
 }
 
-const originalFiles = new Map<string, string>()
-const createdFiles = new Set<string>()
-afterEach(() => {
-  originalFiles.forEach((content, file) => {
-    console.log('restore', file)
-    fs.writeFileSync(file, content, 'utf-8')
-  })
-  createdFiles.forEach((file) => {
-    if (fs.existsSync(file)) fs.unlinkSync(file)
-  })
-  originalFiles.clear()
-  createdFiles.clear()
-})
-
-export function createFile(file: string, content: string): void {
-  createdFiles.add(file)
-  fs.mkdirSync(dirname(file), { recursive: true })
-  fs.writeFileSync(file, content, 'utf-8')
+type FixtureEditor = {
+  editFile: (file: string, callback: (content: string) => string) => void
 }
 
-export function editFile(
-  file: string,
-  callback: (content: string) => string,
-): void {
-  console.log('edit', file)
-  const content = fs.readFileSync(file, 'utf-8')
-  if (!originalFiles.has(file)) originalFiles.set(file, content)
-  fs.writeFileSync(file, callback(content), 'utf-8')
+export function createFixtureEditor(): FixtureEditor {
+  const originalFiles = new Map<string, string>()
+  onTestFinished(() => {
+    originalFiles.forEach((content, file) => {
+      fs.writeFileSync(file, content, 'utf-8')
+    })
+    originalFiles.clear()
+  })
+
+  return {
+    editFile(file, callback) {
+      const content = fs.readFileSync(file, 'utf-8')
+      if (!originalFiles.has(file)) originalFiles.set(file, content)
+      fs.writeFileSync(file, callback(content), 'utf-8')
+    },
+  }
 }
 
 export function resolvePath(baseUrl: string, path: string): string {

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -96,12 +96,8 @@ export async function createModuleRunnerTester(
   })
 
   afterEach<TestClient>(async (t) => {
-    try {
-      await t.runner.close()
-      await t.server.close()
-    } catch (e) {
-      console.error(e)
-    }
+    await t.runner.close()
+    await t.server.close()
   })
 
   return test as TestAPI<TestClient>
@@ -111,6 +107,7 @@ const originalFiles = new Map<string, string>()
 const createdFiles = new Set<string>()
 afterEach(() => {
   originalFiles.forEach((content, file) => {
+    console.log('restore', file)
     fs.writeFileSync(file, content, 'utf-8')
   })
   createdFiles.forEach((file) => {
@@ -130,6 +127,7 @@ export function editFile(
   file: string,
   callback: (content: string) => string,
 ): void {
+  console.log('edit', file)
   const content = fs.readFileSync(file, 'utf-8')
   if (!originalFiles.has(file)) originalFiles.set(file, content)
   fs.writeFileSync(file, callback(content), 'utf-8')

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -96,8 +96,12 @@ export async function createModuleRunnerTester(
   })
 
   afterEach<TestClient>(async (t) => {
-    await t.runner.close()
-    await t.server.close()
+    try {
+      await t.runner.close()
+      await t.server.close()
+    } catch (e) {
+      console.error(e)
+    }
   })
 
   return test as TestAPI<TestClient>


### PR DESCRIPTION
### Description

This PR tries to fix the flaky fails in rolldown repo.
https://github.com/rolldown/rolldown/actions/runs/15458245223/job/43514409981#step:6:856
It doesn't reproduce locally.

From what I tested, it seems `afterEach` in `packages/vite/src/node/ssr/runtime/__tests__/utils.ts` is not called sometimes.
If I change it to use `onTestFinished`, it didn't fail.

Maybe there's a bug in Vitest? cc @hi-ogawa 

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
