### PR TITLE
feat(native-plugin): use js alias plugin in dev environment

### DIFF
--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -52,7 +52,7 @@ export async function resolvePlugins(
     !isBuild ? optimizedDepsPlugin() : null,
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     !isBuild ? preAliasPlugin(config) : null,
-    enableNativePlugin === true
+    enableNativePlugin === true && isBuild
       ? nativeAliasPlugin({
           entries: config.resolve.alias.map((item) => {
             return {


### PR DESCRIPTION
### Description

The native plugin uses the internal rolldown context, so we use js plugin in dev environment.
