### PR TITLE
feat(native-plugin): use js import analysis build plugin in dev environment

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -761,7 +761,10 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
     },
   }
 
-  if (config.experimental.enableNativePlugin === true) {
+  if (
+    config.experimental.enableNativePlugin === true &&
+    config.command === 'build'
+  ) {
     delete plugin.transform
     delete plugin.resolveId
     delete plugin.load


### PR DESCRIPTION
### Description

Due to the native plugin uses `transform_ast` hook, so we use js import analysis build plugin to make `experimental.enableNativePlugin` works in dev environment.