### PR TITLE
feat(native-plugin): use js dynamic import vars plugin in dev environment

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -167,7 +167,10 @@ export async function transformDynamicImport(
 }
 
 export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
-  if (config.experimental.enableNativePlugin === true) {
+  if (
+    config.experimental.enableNativePlugin === true &&
+    config.command === 'build'
+  ) {
     return nativeDynamicImportVarsPlugin()
   }
 


### PR DESCRIPTION
### Description

The native plugin uses the `transform_ast` hook, so we use the js plugin in the dev environment.