### PR TITLE
feat(native-plugin): use js modulepreload polyfill plugin in dev environment

### DIFF
--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -8,16 +8,16 @@ export const modulePreloadPolyfillId = 'vite/modulepreload-polyfill'
 const resolvedModulePreloadPolyfillId = '\0' + modulePreloadPolyfillId + '.js'
 
 export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
-  if (config.experimental.enableNativePlugin === true) {
+  if (
+    config.experimental.enableNativePlugin === true &&
+    config.command === 'build'
+  ) {
     return perEnvironmentPlugin(
       'native:modulepreload-polyfill',
       (environment) => {
-        if (
-          config.command !== 'build' ||
-          environment.config.consumer !== 'client'
-        )
-          return false
-        return nativeModulePreloadPolyfillPlugin()
+        return nativeModulePreloadPolyfillPlugin({
+          isServer: environment.config.consumer !== 'client',
+        })
       },
     )
   }


### PR DESCRIPTION
### Description

- ~~Vite only used this plugin for build, so removing this plugin won't affect dev~~
- ~~The native plugin is fully aligned in build environment~~
~~What I'm curious about is whether we can move it into `resolveBuildPlugins`.~~

The native plugin used internal context, so we use js plugin in dev environment.