### PR TITLE
refactor: move the condition related to `enableNativePlugin` to the plugin file side

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/json.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/json.spec.ts
@@ -35,7 +35,7 @@ describe('transform', () => {
     opts: Required<JsonOptions>,
     isBuild: boolean,
   ) => {
-    const plugin = jsonPlugin(opts, isBuild)
+    const plugin = jsonPlugin(opts, isBuild, false)
     // @ts-expect-error transform.handler should exist
     return plugin.transform.handler(input, 'test.json', { moduleType: 'json' })
       .code

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -4,6 +4,7 @@ import { init, parse as parseImports } from 'es-module-lexer'
 import type { ImportSpecifier } from 'es-module-lexer'
 import { parseAst } from 'rolldown/parseAst'
 import { dynamicImportToGlob } from '@rollup/plugin-dynamic-import-vars'
+import { dynamicImportVarsPlugin as nativeDynamicImportVarsPlugin } from 'rolldown/experimental'
 import { exactRegex } from '@rolldown/pluginutils'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
@@ -166,6 +167,10 @@ export async function transformDynamicImport(
 }
 
 export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
+  if (config.experimental.enableNativePlugin === true) {
+    return nativeDynamicImportVarsPlugin()
+  }
+
   const resolve = createBackCompatIdResolver(config, {
     preferRelative: true,
     tryIndex: false,

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -16,6 +16,7 @@ import { stringifyQuery } from 'ufo'
 import type { GeneralImportGlobOptions } from 'types/importGlob'
 import { parseAstAsync } from 'rolldown/parseAst'
 import { escapePath, glob } from 'tinyglobby'
+import { importGlobPlugin as nativeImportGlobPlugin } from 'rolldown/experimental'
 import type { Plugin } from '../plugin'
 import type { EnvironmentModuleNode } from '../server/moduleGraph'
 import type { ResolvedConfig } from '../config'
@@ -41,6 +42,13 @@ interface ParsedGeneralImportGlobOptions extends GeneralImportGlobOptions {
 }
 
 export function importGlobPlugin(config: ResolvedConfig): Plugin {
+  if (config.experimental.enableNativePlugin === true) {
+    return nativeImportGlobPlugin({
+      root: config.root,
+      restoreQueryExtension: config.experimental.importGlobRestoreExtension,
+    })
+  }
+
   const importGlobMaps = new Map<
     Environment,
     Map<string, Array<(file: string) => boolean>>

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -102,7 +102,7 @@ export async function resolvePlugins(
     cssPlugin(config),
     esbuildBannerFooterCompatPlugin(config),
     config.oxc !== false ? oxcPlugin(config) : null,
-    jsonPlugin(config, isBuild),
+    jsonPlugin(config.json, isBuild, enableNativePlugin === true),
     wasmHelperPlugin(config),
     webWorkerPlugin(config),
     assetPlugin(config),

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -1,26 +1,13 @@
-import url from 'node:url'
 import aliasPlugin, { type ResolverFunction } from '@rollup/plugin-alias'
 import type { ObjectHook } from 'rolldown'
-import type { TransformOptions as OxcTransformOptions } from 'rolldown/experimental'
-import {
-  aliasPlugin as nativeAliasPlugin,
-  dynamicImportVarsPlugin as nativeDynamicImportVarsPlugin,
-  importGlobPlugin as nativeImportGlobPlugin,
-  jsonPlugin as nativeJsonPlugin,
-  modulePreloadPolyfillPlugin as nativeModulePreloadPolyfillPlugin,
-  transformPlugin as nativeTransformPlugin,
-  wasmFallbackPlugin as nativeWasmFallbackPlugin,
-  wasmHelperPlugin as nativeWasmHelperPlugin,
-} from 'rolldown/experimental'
+import { aliasPlugin as nativeAliasPlugin } from 'rolldown/experimental'
 import type { PluginHookUtils, ResolvedConfig } from '../config'
 import {
   type HookHandler,
   type Plugin,
   type PluginWithRequiredHook,
-  perEnvironmentPlugin,
 } from '../plugin'
 import { watchPackageDataPlugin } from '../packages'
-import { normalizePath } from '../utils'
 import { jsonPlugin } from './json'
 import { oxcResolvePlugin, resolvePlugin } from './resolve'
 import { optimizedDepsPlugin } from './optimizedDeps'
@@ -44,7 +31,7 @@ import {
   createFilterForTransform,
   createIdFilter,
 } from './pluginFilter'
-import { type OxcOptions, oxcPlugin } from './oxc'
+import { oxcPlugin } from './oxc'
 import { esbuildBannerFooterCompatPlugin } from './esbuildBannerFooterCompatPlugin'
 
 export async function resolvePlugins(
@@ -83,19 +70,7 @@ export async function resolvePlugins(
     ...prePlugins,
 
     modulePreload !== false && modulePreload.polyfill
-      ? enableNativePlugin === true
-        ? perEnvironmentPlugin(
-            'native:modulepreload-polyfill',
-            (environment) => {
-              if (
-                config.command !== 'build' ||
-                environment.config.consumer !== 'client'
-              )
-                return false
-              return nativeModulePreloadPolyfillPlugin()
-            },
-          )
-        : modulePreloadPolyfillPlugin(config)
+      ? modulePreloadPolyfillPlugin(config)
       : null,
     ...(enableNativePlugin
       ? oxcResolvePlugin(
@@ -126,65 +101,23 @@ export async function resolvePlugins(
     htmlInlineProxyPlugin(config),
     cssPlugin(config),
     esbuildBannerFooterCompatPlugin(config),
-    config.oxc !== false
-      ? enableNativePlugin === true
-        ? perEnvironmentPlugin('native:transform', (environment) => {
-            const {
-              jsxInject,
-              include = /\.(m?ts|[jt]sx)$/,
-              exclude = /\.js$/,
-              jsxRefreshInclude,
-              jsxRefreshExclude,
-              ..._transformOptions
-            } = config.oxc as Exclude<OxcOptions, false | undefined>
-
-            const transformOptions: OxcTransformOptions = _transformOptions
-            transformOptions.sourcemap =
-              environment.config.mode !== 'build' ||
-              !!environment.config.build.sourcemap
-
-            return nativeTransformPlugin({
-              include,
-              exclude,
-              jsxRefreshInclude,
-              jsxRefreshExclude,
-              isServerConsumer: environment.config.consumer === 'server',
-              runtimeResolveBase: normalizePath(
-                url.fileURLToPath(import.meta.url),
-              ),
-              jsxInject,
-              transformOptions,
-            })
-          })
-        : oxcPlugin(config)
-      : null,
-    enableNativePlugin === true
-      ? nativeJsonPlugin({ ...config.json, minify: isBuild })
-      : jsonPlugin(config.json, isBuild),
-    enableNativePlugin === true ? nativeWasmHelperPlugin() : wasmHelperPlugin(),
+    config.oxc !== false ? oxcPlugin(config) : null,
+    jsonPlugin(config, isBuild),
+    wasmHelperPlugin(config),
     webWorkerPlugin(config),
     assetPlugin(config),
 
     ...normalPlugins,
 
-    enableNativePlugin === true
-      ? nativeWasmFallbackPlugin()
-      : wasmFallbackPlugin(),
+    wasmFallbackPlugin(config),
     definePlugin(config),
     cssPostPlugin(config),
     isBuild && buildHtmlPlugin(config),
     workerImportMetaUrlPlugin(config),
     assetImportMetaUrlPlugin(config),
     ...buildPlugins.pre,
-    enableNativePlugin === true
-      ? nativeDynamicImportVarsPlugin()
-      : dynamicImportVarsPlugin(config),
-    enableNativePlugin === true
-      ? nativeImportGlobPlugin({
-          root: config.root,
-          restoreQueryExtension: config.experimental.importGlobRestoreExtension,
-        })
-      : importGlobPlugin(config),
+    dynamicImportVarsPlugin(config),
+    importGlobPlugin(config),
 
     ...postPlugins,
 

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -7,9 +7,11 @@
  */
 
 import { dataToEsm, makeLegalIdentifier } from '@rollup/pluginutils'
+import { jsonPlugin as nativeJsonPlugin } from 'rolldown/experimental'
 import { SPECIAL_QUERY_RE } from '../constants'
 import type { Plugin } from '../plugin'
 import { stripBomTag } from '../utils'
+import type { ResolvedConfig } from '..'
 import { inlineRE, noInlineRE } from './asset'
 
 export interface JsonOptions {
@@ -37,10 +39,11 @@ const jsonLangRE = new RegExp(jsonLangs)
 export const isJSONRequest = (request: string): boolean =>
   jsonLangRE.test(request)
 
-export function jsonPlugin(
-  options: Required<JsonOptions>,
-  isBuild: boolean,
-): Plugin {
+export function jsonPlugin(config: ResolvedConfig, isBuild: boolean): Plugin {
+  const options = config.json
+  if (config.experimental.enableNativePlugin === true) {
+    return nativeJsonPlugin({ ...options, minify: isBuild })
+  }
   const plugin = {
     name: 'vite:json',
 

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -46,6 +46,7 @@ export function jsonPlugin(
   if (enableNativePlugin) {
     return nativeJsonPlugin({ ...options, minify: isBuild })
   }
+
   const plugin = {
     name: 'vite:json',
 

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -11,7 +11,6 @@ import { jsonPlugin as nativeJsonPlugin } from 'rolldown/experimental'
 import { SPECIAL_QUERY_RE } from '../constants'
 import type { Plugin } from '../plugin'
 import { stripBomTag } from '../utils'
-import type { ResolvedConfig } from '..'
 import { inlineRE, noInlineRE } from './asset'
 
 export interface JsonOptions {
@@ -39,9 +38,12 @@ const jsonLangRE = new RegExp(jsonLangs)
 export const isJSONRequest = (request: string): boolean =>
   jsonLangRE.test(request)
 
-export function jsonPlugin(config: ResolvedConfig, isBuild: boolean): Plugin {
-  const options = config.json
-  if (config.experimental.enableNativePlugin === true) {
+export function jsonPlugin(
+  options: Required<JsonOptions>,
+  isBuild: boolean,
+  enableNativePlugin: boolean,
+): Plugin {
+  if (enableNativePlugin) {
     return nativeJsonPlugin({ ...options, minify: isBuild })
   }
   const plugin = {

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -1,5 +1,6 @@
 import { exactRegex } from '@rolldown/pluginutils'
-import type { ResolvedConfig } from '..'
+import { modulePreloadPolyfillPlugin as nativeModulePreloadPolyfillPlugin } from 'rolldown/experimental'
+import { type ResolvedConfig, perEnvironmentPlugin } from '..'
 import type { Plugin } from '../plugin'
 import { isModernFlag } from './importAnalysisBuild'
 
@@ -7,6 +8,20 @@ export const modulePreloadPolyfillId = 'vite/modulepreload-polyfill'
 const resolvedModulePreloadPolyfillId = '\0' + modulePreloadPolyfillId + '.js'
 
 export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
+  if (config.experimental.enableNativePlugin === true) {
+    return perEnvironmentPlugin(
+      'native:modulepreload-polyfill',
+      (environment) => {
+        if (
+          config.command !== 'build' ||
+          environment.config.consumer !== 'client'
+        )
+          return false
+        return nativeModulePreloadPolyfillPlugin()
+      },
+    )
+  }
+
   let polyfillString: string | undefined
 
   return {

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -4,7 +4,6 @@ import type {
   TransformOptions as OxcTransformOptions,
   TransformResult as OxcTransformResult,
 } from 'rolldown/experimental'
-
 import {
   transformPlugin as nativeTransformPlugin,
   transform,

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -4,7 +4,11 @@ import type {
   TransformOptions as OxcTransformOptions,
   TransformResult as OxcTransformResult,
 } from 'rolldown/experimental'
-import { transform } from 'rolldown/experimental'
+
+import {
+  transformPlugin as nativeTransformPlugin,
+  transform,
+} from 'rolldown/experimental'
 import type { RawSourceMap } from '@ampproject/remapping'
 import type { InternalModuleFormat, RollupError, SourceMap } from 'rolldown'
 import { rolldown } from 'rolldown'
@@ -22,7 +26,7 @@ import {
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { cleanUrl } from '../../shared/utils'
-import type { Environment } from '..'
+import { type Environment, perEnvironmentPlugin } from '..'
 import type { ViteDevServer } from '../server'
 import { JS_TYPES_RE } from '../constants'
 import type { Logger } from '../logger'
@@ -267,6 +271,35 @@ function resolveTsconfigTarget(target: string | undefined): number | 'next' {
 }
 
 export function oxcPlugin(config: ResolvedConfig): Plugin {
+  if (config.experimental.enableNativePlugin === true) {
+    return perEnvironmentPlugin('native:transform', (environment) => {
+      const {
+        jsxInject,
+        include = /\.(m?ts|[jt]sx)$/,
+        exclude = /\.js$/,
+        jsxRefreshInclude,
+        jsxRefreshExclude,
+        ..._transformOptions
+      } = config.oxc as Exclude<OxcOptions, false | undefined>
+
+      const transformOptions: OxcTransformOptions = _transformOptions
+      transformOptions.sourcemap =
+        environment.config.mode !== 'build' ||
+        !!environment.config.build.sourcemap
+
+      return nativeTransformPlugin({
+        include,
+        exclude,
+        jsxRefreshInclude,
+        jsxRefreshExclude,
+        isServerConsumer: environment.config.consumer === 'server',
+        runtimeResolveBase: normalizePath(url.fileURLToPath(import.meta.url)),
+        jsxInject,
+        transformOptions,
+      })
+    })
+  }
+
   const options = config.oxc as OxcOptions
   const {
     jsxInject,

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -1,5 +1,10 @@
 import { exactRegex } from '@rolldown/pluginutils'
+import {
+  wasmFallbackPlugin as nativeWasmFallbackPlugin,
+  wasmHelperPlugin as nativeWasmHelperPlugin,
+} from 'rolldown/experimental'
 import type { Plugin } from '../plugin'
+import type { ResolvedConfig } from '..'
 import { fileToUrl } from './asset'
 
 const wasmHelperId = '\0vite/wasm-helper.js'
@@ -48,7 +53,11 @@ const wasmHelper = async (opts = {}, url: string) => {
 
 const wasmHelperCode = wasmHelper.toString()
 
-export const wasmHelperPlugin = (): Plugin => {
+export const wasmHelperPlugin = (config: ResolvedConfig): Plugin => {
+  if (config.experimental.enableNativePlugin === true) {
+    return nativeWasmHelperPlugin()
+  }
+
   return {
     name: 'vite:wasm-helper',
 
@@ -77,7 +86,11 @@ export const wasmHelperPlugin = (): Plugin => {
   }
 }
 
-export const wasmFallbackPlugin = (): Plugin => {
+export const wasmFallbackPlugin = (config: ResolvedConfig): Plugin => {
+  if (config.experimental.enableNativePlugin === true) {
+    return nativeWasmFallbackPlugin()
+  }
+
   return {
     name: 'vite:wasm-fallback',
 

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -4,8 +4,9 @@ import type { OutputChunk, RollupError } from 'rolldown'
 import colors from 'picocolors'
 import { type ImportSpecifier, init, parse } from 'es-module-lexer'
 import type { ChunkMetadata } from 'types/metadata'
+import { webWorkerPostPlugin as nativeWebWorkerPostPlugin } from 'rolldown/experimental'
 import type { ResolvedConfig } from '../config'
-import type { Plugin } from '../plugin'
+import { type Plugin, perEnvironmentPlugin } from '../plugin'
 import { ENV_ENTRY, ENV_PUBLIC_PATH } from '../constants'
 import {
   encodeURIPath,
@@ -240,7 +241,17 @@ export async function workerFileToUrl(
   return encodeWorkerAssetFileName(fileName, workerMap)
 }
 
-export function webWorkerPostPlugin(): Plugin {
+export function webWorkerPostPlugin(config: ResolvedConfig): Plugin {
+  if (config.experimental.enableNativePlugin === true) {
+    return perEnvironmentPlugin(
+      'native:web-worker-post-plugin',
+      (environment) => {
+        if (environment.config.worker.format === 'iife') {
+          return nativeWebWorkerPostPlugin()
+        }
+      },
+    )
+  }
   return {
     name: 'vite:worker-post',
     transform: {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -252,6 +252,7 @@ export function webWorkerPostPlugin(config: ResolvedConfig): Plugin {
       },
     )
   }
+
   return {
     name: 'vite:worker-post',
     transform: {


### PR DESCRIPTION
### Description

Would you make a PR that does this refactor (moving the condition to the plugin file side) for all the native plugins first so that we can split the refactor and the behavior change?

_Originally posted by @sapphi-red in https://github.com/vitejs/rolldown-vite/pull/238#discussion_r2134943882_
            
