### PR TITLE
feat(native-plugin): use js wasm helper in dev environment

### DIFF
--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -54,7 +54,10 @@ const wasmHelper = async (opts = {}, url: string) => {
 const wasmHelperCode = wasmHelper.toString()
 
 export const wasmHelperPlugin = (config: ResolvedConfig): Plugin => {
-  if (config.experimental.enableNativePlugin === true) {
+  if (
+    config.experimental.enableNativePlugin === true &&
+    config.command === 'build'
+  ) {
     return nativeWasmHelperPlugin()
   }
 


### PR DESCRIPTION
### Description

The native plugin uses the internal rolldown context, so we use js plugin in dev environment.
