### PR TITLE
feat(native-plugin): use js json plugin in dev environment

### DIFF
--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -43,7 +43,7 @@ export function jsonPlugin(
   isBuild: boolean,
   enableNativePlugin: boolean,
 ): Plugin {
-  if (enableNativePlugin) {
+  if (enableNativePlugin && isBuild) {
     return nativeJsonPlugin({ ...options, minify: isBuild })
   }
 


### PR DESCRIPTION
### Description

For the `transform` hook, their sourcemap chain contexts are inconsistent — in the dev environment, JS plugins run on the Node side, while native plugins run on the Rust side. So we use js json plugin in dev environment.