### PR TITLE
fix: set viteMetadata for `writeBundle` hook

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1317,7 +1317,7 @@ function wrapEnvironmentHook<HookName extends keyof Plugin>(
     if (hookName === 'augmentChunkHash') {
       injectChunkMetadata(chunkMetadataMap, args[0])
     }
-    if (hookName === 'generateBundle') {
+    if (hookName === 'generateBundle' || hookName === 'writeBundle') {
       const bundle = args[1] as OutputBundle
       for (const chunk of Object.values(bundle)) {
         if (chunk.type === 'chunk') {


### PR DESCRIPTION
### Description

`viteMetadata` was not able to access from the `bundle` parameter of `writeBundle` hook.

fixes #264

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
