### PR TITLE
fix: resolve oxc runtime from Vite directory correctly

### DIFF
--- a/packages/vite/rolldown.config.ts
+++ b/packages/vite/rolldown.config.ts
@@ -351,7 +351,7 @@ function buildTimeImportMetaUrlPlugin(): Plugin {
         for (const { t, ss, se } of imports) {
           if (t === 3 && code.slice(se, se + 4) === '.url') {
             // ignore import.meta.url with /** #__KEEP__ */ comment
-            if (keepCommentRE.test(code.slice(0, se))) {
+            if (keepCommentRE.test(code.slice(0, ss))) {
               keepCommentRE.lastIndex = 0
               continue
             }

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -295,7 +295,9 @@ export function oxcPlugin(config: ResolvedConfig): Plugin {
         jsxRefreshInclude,
         jsxRefreshExclude,
         isServerConsumer: environment.config.consumer === 'server',
-        runtimeResolveBase: normalizePath(url.fileURLToPath(import.meta.url)),
+        runtimeResolveBase: normalizePath(
+          url.fileURLToPath(/** #__KEEP__ */ import.meta.url),
+        ),
         jsxInject,
         transformOptions,
       })
@@ -344,7 +346,9 @@ export function oxcPlugin(config: ResolvedConfig): Plugin {
 
     return result
   }
-  const runtimeResolveBase = normalizePath(url.fileURLToPath(import.meta.url))
+  const runtimeResolveBase = normalizePath(
+    url.fileURLToPath(/** #__KEEP__ */ import.meta.url),
+  )
 
   let server: ViteDevServer
 
@@ -526,7 +530,7 @@ async function generateRuntimeHelpers(
   runtimeHelpers: readonly [string, string][],
 ): Promise<string> {
   const bundle = await rolldown({
-    cwd: url.fileURLToPath(import.meta.url),
+    cwd: url.fileURLToPath(/** #__KEEP__ */ import.meta.url),
     input: 'entrypoint',
     platform: 'neutral',
     logLevel: 'silent',


### PR DESCRIPTION
### Description

`import.meta.url` was replaced in build and was pointing a different directory.

Includes https://github.com/vitejs/vite/pull/20235

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
