### PR TITLE
feat(native-plugin): fallback to js alias plugin when alias entries include `customResolver`

### DIFF
--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -52,7 +52,9 @@ export async function resolvePlugins(
     !isBuild ? optimizedDepsPlugin() : null,
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     !isBuild ? preAliasPlugin(config) : null,
-    enableNativePlugin === true && isBuild
+    enableNativePlugin === true &&
+    isBuild &&
+    !config.resolve.alias.some((v) => v.customResolver)
       ? nativeAliasPlugin({
           entries: config.resolve.alias.map((item) => {
             return {


### PR DESCRIPTION
### Description

Native alias plugin currently do not support `customResolver`, this is being tracked in https://github.com/rolldown/rolldown/issues/4973.