### PR TITLE
fix: dep optimizer should not treeshake

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -792,6 +792,7 @@ async function prepareRolldownOptimizerRun(
       plugins,
       define,
       platform,
+      treeshake: false,
       resolve: {
         extensions: ['.tsx', '.ts', '.jsx', '.js', '.css', '.json'],
         ...rollupOptions.resolve,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

When using rolldown-vite to optimize a third-party dependency.

For some dependency,it will remove code like  `import './a.js'`.

Maybe it is hard to reproduce.

And I think `optimizer` should not treeshake the bundled code.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
