### PR TITLE
feat(native-plugin): avoid presetting `process.env.NODE_ENV` when platform is `browser`

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -118,6 +118,12 @@ export function definePlugin(config: ResolvedConfig): Plugin {
         )
         define['import.meta.env'] = importMetaEnvVal
         define['import.meta.env.*'] = 'undefined'
+        if (
+          option.platform === 'browser' &&
+          !Object.hasOwn(define, 'process.env.NODE_ENV')
+        ) {
+          define['process.env.NODE_ENV'] = "'process.env.NODE_ENV'"
+        }
         option.define = define
       },
     }


### PR DESCRIPTION
### Description

See https://github.com/rolldown/rolldown/blob/9e8acf2/crates/rolldown/src/utils/normalize_options.rs#L93-L100
