### PR TITLE
feat(native-plugin): use js define plugin in dev environment

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -109,7 +109,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     return pattern
   }
 
-  if (config.experimental.enableNativePlugin === true) {
+  if (config.experimental.enableNativePlugin === true && isBuild) {
     return {
       name: 'vite:define',
       options(option) {


### PR DESCRIPTION
### Description

The `define` option is not supported in the dev environment.

