### PR TITLE
refactor: use Rolldown's `@oxc-project/runtime`

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -81,7 +81,6 @@
   },
   "//": "READ CONTRIBUTING.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
-    "@oxc-project/runtime": "0.75.0",
     "fdir": "^6.4.6",
     "lightningcss": "^1.30.1",
     "picomatch": "^4.0.2",

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import url from 'node:url'
+import { createRequire } from 'node:module'
 import type {
   TransformOptions as OxcTransformOptions,
   TransformResult as OxcTransformResult,
@@ -372,8 +373,9 @@ export function oxcPlugin(config: ResolvedConfig): Plugin {
 
     return result
   }
+  const require = createRequire(/** #__KEEP__ */ import.meta.url)
   const runtimeResolveBase = normalizePath(
-    url.fileURLToPath(/** #__KEEP__ */ import.meta.url),
+    require.resolve('rolldown/package.json'),
   )
 
   let server: ViteDevServer
@@ -389,7 +391,7 @@ export function oxcPlugin(config: ResolvedConfig): Plugin {
       },
       async handler(id, _importer, opts) {
         // @oxc-project/runtime imports will be injected by OXC transform
-        // since it's injected by the transform, @oxc-project/runtime should be resolved to the one Vite depends on
+        // since it's injected by the transform, @oxc-project/runtime should be resolved to the one Rolldown depends on
         const resolved = await this.resolve(id, runtimeResolveBase, opts)
         return resolved
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,9 +220,6 @@ importers:
 
   packages/vite:
     dependencies:
-      '@oxc-project/runtime':
-        specifier: 0.75.0
-        version: 0.75.0
       fdir:
         specifier: ^6.4.6
         version: 6.4.6(picomatch@4.0.2)


### PR DESCRIPTION
### Description

Rolldown now has `@oxc-project/runtime` as a dep instead of peerDep so we can use that.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
