### PR TITLE
fix(worker): match worker import meta more quickly

### DIFF
--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -181,7 +181,7 @@ async function getWorkerType(
 }
 
 const workerImportMetaUrlRE =
-  /new\s+(?:Worker|SharedWorker).+new\s+URL.+import\.meta\.url/s
+  /new\s+(?:Worker|SharedWorker)\s*\(\s*new\s+URL.+?import\.meta\.url/s
 
 export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'


### PR DESCRIPTION
### Description

Changed the regex used for hook filters in `workerImportMetaUrlPlugin`.

The previous one caused many unnecessary backtracks and caused `Maximum call stack size exceeded` error when the file is large.

[Example on regex101 (before, taking 825steps)](https://regex101.com/r/pX8XIQ/1)
[Example on regex101 (after, taking 39steps)](https://regex101.com/r/iqjUUC/1)

fixes #332

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
