### PR TITLE
refactor: introduce `*.rolldownOptions` and deprecate `*.rollupOptions`

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -273,6 +273,253 @@ describe('mergeConfig', () => {
       ),
     ).toThrowError('Cannot merge config in form of callback')
   })
+
+  test('handles `rollupOptions`', () => {
+    const baseConfig = defineConfig({
+      build: {
+        rollupOptions: {
+          treeshake: false,
+        },
+      },
+      worker: {
+        rollupOptions: {
+          treeshake: false,
+        },
+      },
+      optimizeDeps: {
+        rollupOptions: {
+          treeshake: false,
+        },
+      },
+      ssr: {
+        optimizeDeps: {
+          rollupOptions: {
+            treeshake: false,
+          },
+        },
+      },
+    })
+
+    const newConfig = defineConfig({
+      build: {
+        rollupOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      worker: {
+        rollupOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      optimizeDeps: {
+        rollupOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      ssr: {
+        optimizeDeps: {
+          rollupOptions: {
+            output: {
+              minifyInternalExports: true,
+            },
+          },
+        },
+      },
+    })
+
+    const mergedConfig = mergeConfig(baseConfig, newConfig)
+
+    const expected = {
+      treeshake: false,
+      output: {
+        minifyInternalExports: true,
+      },
+    }
+    expect(mergedConfig.build.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.build.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.worker.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.worker.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.optimizeDeps.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.optimizeDeps.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.ssr.optimizeDeps.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.ssr.optimizeDeps.rolldownOptions).toStrictEqual(
+      expected,
+    )
+  })
+
+  test('handles `build.rolldownOptions`', () => {
+    const baseConfig = defineConfig({
+      build: {
+        rolldownOptions: {
+          treeshake: false,
+        },
+      },
+      worker: {
+        rolldownOptions: {
+          treeshake: false,
+        },
+      },
+      optimizeDeps: {
+        rolldownOptions: {
+          treeshake: false,
+        },
+      },
+      ssr: {
+        optimizeDeps: {
+          rolldownOptions: {
+            treeshake: false,
+          },
+        },
+      },
+    })
+
+    const newConfig = defineConfig({
+      build: {
+        rolldownOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      worker: {
+        rolldownOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      optimizeDeps: {
+        rolldownOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      ssr: {
+        optimizeDeps: {
+          rolldownOptions: {
+            output: {
+              minifyInternalExports: true,
+            },
+          },
+        },
+      },
+    })
+
+    const mergedConfig = mergeConfig(baseConfig, newConfig)
+
+    const expected = {
+      treeshake: false,
+      output: {
+        minifyInternalExports: true,
+      },
+    }
+    expect(mergedConfig.build.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.build.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.worker.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.worker.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.optimizeDeps.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.optimizeDeps.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.ssr.optimizeDeps.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.ssr.optimizeDeps.rolldownOptions).toStrictEqual(
+      expected,
+    )
+  })
+
+  test('syncs `build.rollupOptions` and `build.rolldownOptions`', () => {
+    const baseConfig = defineConfig({
+      build: {
+        rollupOptions: {
+          treeshake: false,
+        },
+      },
+      worker: {
+        rollupOptions: {
+          treeshake: false,
+        },
+      },
+      optimizeDeps: {
+        rollupOptions: {
+          treeshake: false,
+        },
+      },
+      ssr: {
+        optimizeDeps: {
+          rollupOptions: {
+            treeshake: false,
+          },
+        },
+      },
+    })
+
+    const newConfig = defineConfig({
+      build: {
+        rolldownOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      worker: {
+        rolldownOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      optimizeDeps: {
+        rolldownOptions: {
+          output: {
+            minifyInternalExports: true,
+          },
+        },
+      },
+      ssr: {
+        optimizeDeps: {
+          rollupOptions: {
+            output: {
+              minifyInternalExports: true,
+            },
+          },
+        },
+      },
+    })
+
+    const mergedConfig = mergeConfig(baseConfig, newConfig) as UserConfig
+
+    const expected = {
+      treeshake: false,
+      output: {
+        minifyInternalExports: true,
+      },
+    }
+    expect(mergedConfig.build!.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.build!.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.worker!.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.worker!.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.optimizeDeps!.rollupOptions).toStrictEqual(expected)
+    expect(mergedConfig.optimizeDeps!.rolldownOptions).toStrictEqual(expected)
+    expect(mergedConfig.ssr!.optimizeDeps!.rollupOptions).toStrictEqual(
+      expected,
+    )
+    expect(mergedConfig.ssr!.optimizeDeps!.rolldownOptions).toStrictEqual(
+      expected,
+    )
+
+    const upOutput = mergedConfig.build!.rollupOptions!.output!
+    if (Array.isArray(upOutput)) throw new Error()
+    const downOutput = mergedConfig.build!.rolldownOptions!.output!
+    if (Array.isArray(downOutput)) throw new Error()
+    upOutput.hashCharacters = 'base36'
+    expect(upOutput.hashCharacters).toBe('base36')
+    expect(downOutput.hashCharacters).toBe('base36')
+  })
 })
 
 describe('resolveEnvPrefix', () => {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -54,6 +54,7 @@ import {
   mergeConfig,
   mergeWithDefaults,
   partialEncodeURIPath,
+  setupRollupOptionCompat,
   unique,
 } from './utils'
 import { perEnvironmentPlugin } from './plugin'
@@ -187,10 +188,15 @@ export interface BuildEnvironmentOptions {
    */
   terserOptions?: TerserOptions
   /**
-   * Will be merged with internal rollup options.
-   * https://rollupjs.org/configuration-options/
+   * Alias to `rolldownOptions`
+   * @deprecated Use `rolldownOptions` instead.
    */
   rollupOptions?: RolldownOptions
+  /**
+   * Will be merged with internal rolldown options.
+   * https://rolldown.rs/reference/config-options
+   */
+  rolldownOptions?: RolldownOptions
   /**
    * Options to pass on to `@rollup/plugin-commonjs`
    */
@@ -373,7 +379,7 @@ export const buildEnvironmentOptionsDefaults = Object.freeze({
   sourcemap: false,
   // minify
   terserOptions: {},
-  rollupOptions: {},
+  rolldownOptions: {},
   commonjsOptions: {
     include: [/node_modules/],
     extensions: ['.js', '.cjs'],
@@ -422,15 +428,16 @@ export function resolveBuildEnvironmentOptions(
       ...buildEnvironmentOptionsDefaults,
       cssCodeSplit: !raw.lib,
       minify: consumer === 'server' ? false : 'oxc',
-      rollupOptions: {
-        platform: consumer === 'server' ? 'node' : 'browser',
-      },
+      rollupOptions: {},
+      rolldownOptions: undefined,
       ssr: consumer === 'server',
       emitAssets: consumer === 'client',
       createEnvironment: (name, config) => new BuildEnvironment(name, config),
     } satisfies BuildEnvironmentOptions,
     raw,
   )
+  setupRollupOptionCompat(merged)
+  merged.rolldownOptions.platform ??= consumer === 'server' ? 'node' : 'browser'
 
   // handle special build targets
   if (merged.target === 'baseline-widely-available') {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -437,7 +437,10 @@ export function resolveBuildEnvironmentOptions(
     raw,
   )
   setupRollupOptionCompat(merged)
-  merged.rolldownOptions.platform ??= consumer === 'server' ? 'node' : 'browser'
+  merged.rolldownOptions = {
+    ...merged.rolldownOptions,
+    platform: consumer === 'server' ? 'node' : 'browser',
+  }
 
   // handle special build targets
   if (merged.target === 'baseline-widely-available') {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -84,6 +84,7 @@ import {
   nodeLikeBuiltins,
   normalizeAlias,
   normalizePath,
+  setupRollupOptionCompat,
 } from './utils'
 import {
   createPluginHookUtils,
@@ -454,9 +455,17 @@ export interface UserConfig extends DefaultEnvironmentOptions {
      */
     plugins?: () => PluginOption[]
     /**
-     * Rollup options to build worker bundle
+     * Alias to `rolldownOptions`.
+     * @deprecated Use `rolldownOptions` instead.
      */
     rollupOptions?: Omit<
+      RolldownOptions,
+      'plugins' | 'input' | 'onwarn' | 'preserveEntrySignatures'
+    >
+    /**
+     * Rolldown options to build worker bundle
+     */
+    rolldownOptions?: Omit<
       RolldownOptions,
       'plugins' | 'input' | 'onwarn' | 'preserveEntrySignatures'
     >
@@ -555,7 +564,11 @@ export interface LegacyOptions {
 export interface ResolvedWorkerOptions {
   format: 'es' | 'iife'
   plugins: (bundleChain: string[]) => Promise<ResolvedConfig>
+  /**
+   * @deprecated Use `rolldownOptions` instead.
+   */
   rollupOptions: RolldownOptions
+  rolldownOptions: RolldownOptions
 }
 
 export interface InlineConfig extends UserConfig {
@@ -1263,6 +1276,16 @@ export async function resolveConfig(
   patchPlugins: ((resolvedPlugins: Plugin[]) => void) | undefined = undefined,
 ): Promise<ResolvedConfig> {
   let config = inlineConfig
+  config.build ??= {}
+  setupRollupOptionCompat(config.build)
+  config.worker ??= {}
+  setupRollupOptionCompat(config.worker)
+  config.optimizeDeps ??= {}
+  setupRollupOptionCompat(config.optimizeDeps)
+  config.ssr ??= {}
+  config.ssr.optimizeDeps ??= {}
+  setupRollupOptionCompat(config.ssr.optimizeDeps)
+
   let configFileDependencies: string[] = []
   let mode = inlineConfig.mode || defaultMode
   const isNodeEnvSet = !!process.env.NODE_ENV
@@ -1676,11 +1699,18 @@ export async function resolveConfig(
     return workerResolved
   }
 
-  const resolvedWorkerOptions: ResolvedWorkerOptions = {
+  const resolvedWorkerOptions: Omit<
+    ResolvedWorkerOptions,
+    'rolldownOptions'
+  > & {
+    rolldownOptions: ResolvedWorkerOptions['rolldownOptions'] | undefined
+  } = {
     format: config.worker?.format || 'iife',
     plugins: createWorkerPlugins,
     rollupOptions: config.worker?.rollupOptions || {},
+    rolldownOptions: config.worker?.rolldownOptions, // will be set by setupRollupOptionCompat if undefined
   }
+  setupRollupOptionCompat(resolvedWorkerOptions)
 
   const base = withTrailingSlash(resolvedBase)
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -97,7 +97,16 @@ export interface DepOptimizationConfig {
    * https://esbuild.github.io/api
    */
   esbuildOptions?: DepsOptimizerEsbuildOptions
+  /**
+   * @deprecated Use `rolldownOptions` instead.
+   */
   rollupOptions?: Omit<RolldownOptions, 'input' | 'logLevel' | 'output'> & {
+    output?: Omit<
+      RolldownOutputOptions,
+      'format' | 'sourcemap' | 'dir' | 'banner'
+    >
+  }
+  rolldownOptions?: Omit<RolldownOptions, 'input' | 'logLevel' | 'output'> & {
     output?: Omit<
       RolldownOutputOptions,
       'format' | 'sourcemap' | 'dir' | 'banner'


### PR DESCRIPTION
### Description

Introduced `build.rolldownOptions`, `worker.rolldownOptions`, `optimizeDeps.rolldownOptions`, `ssr.optimizeDeps.rolldownOptions`.

Each `rolldownOptions` are synced with `rollupOptions` (modifying one will update the other).

It is not runtime deprecated yet.
Also the internal code still prefer to use `rollupOptions` to keep the diff smaller.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
