### PR TITLE
fix: respect `rollupOptions.platform` options

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -556,6 +556,64 @@ describe('mergeConfig', () => {
     expect(upOutput.hashCharacters).toBe('base36')
     expect(downOutput.hashCharacters).toBe('base36')
   })
+
+  test('rollupOptions/rolldownOptions.platform', async () => {
+    const testRollupOptions = await resolveConfig(
+      {
+        plugins: [
+          {
+            name: 'set-rollupOptions-platform',
+            configEnvironment(name) {
+              if (name === 'ssr') {
+                return {
+                  build: {
+                    rollupOptions: {
+                      platform: 'neutral',
+                    },
+                  },
+                }
+              }
+            },
+          },
+        ],
+      },
+      'serve',
+    )
+    expect(
+      testRollupOptions.environments.ssr.build.rolldownOptions.platform,
+    ).toBe('neutral')
+    expect(
+      testRollupOptions.environments.client.build.rolldownOptions.platform,
+    ).toBe('browser')
+
+    const testRolldownOptions = await resolveConfig(
+      {
+        plugins: [
+          {
+            name: 'set-rollupOptions-platform',
+            configEnvironment(name) {
+              if (name === 'ssr') {
+                return {
+                  build: {
+                    rolldownOptions: {
+                      platform: 'neutral',
+                    },
+                  },
+                }
+              }
+            },
+          },
+        ],
+      },
+      'serve',
+    )
+    expect(
+      testRolldownOptions.environments.ssr.build.rolldownOptions.platform,
+    ).toBe('neutral')
+    expect(
+      testRolldownOptions.environments.client.build.rolldownOptions.platform,
+    ).toBe('browser')
+  })
 })
 
 describe('resolveEnvPrefix', () => {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -438,8 +438,8 @@ export function resolveBuildEnvironmentOptions(
   )
   setupRollupOptionCompat(merged)
   merged.rolldownOptions = {
-    ...merged.rolldownOptions,
     platform: consumer === 'server' ? 'node' : 'browser',
+    ...merged.rolldownOptions,
   }
 
   // handle special build targets


### PR DESCRIPTION
### Description

After https://github.com/vitejs/rolldown-vite/pull/348, cloudflare plugin's `platform: "neutral"` is overwritten with `platform: "node"` and broke rsc plugin examples.