### PR TITLE
feat: warn if a plugin specified both `rollupOptions` and `rolldownOptions`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -71,6 +71,7 @@ import {
   asyncFlatten,
   createDebugger,
   createFilter,
+  hasBothRollupOptionsAndRolldownOptions,
   isExternalUrl,
   isFilePathESM,
   isInNodeModules,
@@ -2512,6 +2513,12 @@ async function runConfigHook(
     const handler = getHookHandler(hook)
     const res = await handler.call(context, conf, configEnv)
     if (res && res !== conf) {
+      if (hasBothRollupOptionsAndRolldownOptions(res)) {
+        context.warn(
+          `Both \`rollupOptions\` and \`rolldownOptions\` were specified by ${JSON.stringify(p.name)} plugin. ` +
+            `\`rollupOptions\` specified by that plugin will be ignored.`,
+        )
+      }
       conf = mergeConfig(conf, res)
     }
   }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1255,6 +1255,26 @@ const rollupOptionsRootPaths = new Set([
   'ssr.optimizeDeps',
 ])
 
+export function hasBothRollupOptionsAndRolldownOptions(
+  options: Record<string, any>,
+): boolean {
+  for (const opt of [
+    options.build,
+    options.worker,
+    options.optimizeDeps,
+    options.ssr?.optimizeDeps,
+  ]) {
+    if (
+      opt != null &&
+      opt.rollupOptions != null &&
+      opt.rolldownOptions != null
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
 function mergeConfigRecursively(
   defaults: Record<string, any>,
   overrides: Record<string, any>,


### PR DESCRIPTION
### Description

Added a warning for cases like https://github.com/vitejs/rolldown-vite/issues/371

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
