### PR TITLE
fix: `build.minify: 'esbuild'` + native plugins were not working

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -505,14 +505,8 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
     ],
     post: [
       ...buildImportAnalysisPlugin(config),
-      ...(config.nativePluginEnabledLevel >= 1
-        ? []
-        : [
-            buildOxcPlugin(),
-            ...(config.build.minify === 'esbuild'
-              ? [buildEsbuildPlugin()]
-              : []),
-          ]),
+      ...(config.nativePluginEnabledLevel >= 1 ? [] : [buildOxcPlugin()]),
+      ...(config.build.minify === 'esbuild' ? [buildEsbuildPlugin()] : []),
       terserPlugin(config),
       ...(!config.isWorker
         ? [


### PR DESCRIPTION
### Description

No minification was applied when `build.minify: 'esbuild'` + native plugins were used.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
