### PR TITLE
fix(optimizer): avoid mutating `optimizeDeps.rollupOptions.transforms` for stable optimizer hash

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -17,6 +17,7 @@ import {
   asyncFlatten,
   createDebugger,
   dataUrlRE,
+  deepClone,
   externalRE,
   isInNodeModules,
   isObject,
@@ -263,19 +264,20 @@ async function prepareRolldownScanner(
   const { tsconfig } = await loadTsconfigJsonForFile(
     path.join(environment.config.root, '_dummy.js'),
   )
-  rollupOptions.transform ??= {}
+  const transformOptions = deepClone(rollupOptions.transform) ?? {}
   setOxcTransformOptionsFromTsconfigOptions(
-    rollupOptions.transform,
+    transformOptions,
     tsconfig.compilerOptions,
     [], // NOTE: ignore warnings as the same warning will be shown by the plugin container
   )
-  if (typeof rollupOptions.transform.jsx === 'object') {
-    rollupOptions.transform.jsx.development ??= !environment.config.isProduction
+  if (typeof transformOptions.jsx === 'object') {
+    transformOptions.jsx.development ??= !environment.config.isProduction
   }
 
   async function build() {
     await scan({
       ...rollupOptions,
+      transform: transformOptions,
       input: entries,
       logLevel: 'silent',
       plugins,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1166,7 +1166,7 @@ type DeepWritable<T> =
         ? T
         : { -readonly [P in keyof T]: DeepWritable<T[P]> }
 
-function deepClone<T>(value: T): DeepWritable<T> {
+export function deepClone<T>(value: T): DeepWritable<T> {
   if (Array.isArray(value)) {
     return value.map((v) => deepClone(v)) as DeepWritable<T>
   }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/rolldown-vite/issues/416

It looks like this is what's happening.