### PR TITLE
fix: set transform target

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -622,6 +622,10 @@ function resolveRolldownOptions(
       // disable builtin process.env.NODE_ENV replacement as it is handled by the define plugin
       'process.env.NODE_ENV': 'process.env.NODE_ENV',
     },
+    transform: {
+      target: options.target === false ? undefined : options.target,
+      ...options.rollupOptions.transform,
+    },
     // TODO: remove this and enable rolldown's CSS support later
     moduleTypes: {
       ...options.rollupOptions.moduleTypes,


### PR DESCRIPTION
### Description

This will add additional overhead when the native plugin is disabled because the transformer will try to run even if it's already done by the js plugin, but that should be fine.

refs https://github.com/vitejs/rolldown-vite/issues/440, https://github.com/vitejs/rolldown-vite/issues/404

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
