### PR TITLE
fix: trigger watchChange hook for all environments for native resolver

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -267,7 +267,7 @@ export function oxcResolvePlugin(
             ? options.noExternal
             : [options.noExternal]
 
-        return viteResolvePlugin({
+        const plugin = viteResolvePlugin({
           resolveOptions: {
             isBuild: options.isBuild,
             isProduction: options.isProduction,
@@ -382,6 +382,8 @@ export function oxcResolvePlugin(
               }
             : {}),
         })
+        ;(plugin as Plugin).perEnvironmentWatchChangeDuringDev = true
+        return plugin
       },
     ),
   ]


### PR DESCRIPTION
### Description

watchChange hook should be triggered for all environments for the native resolver plugin so that the resolver cache is properly invalidated.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
