### PR TITLE
fix: disable resolver cache when watcher is disabled

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -292,6 +292,10 @@ export function oxcResolvePlugin(
           external: options.external,
           noExternal: noExternal,
           dedupe: options.dedupe,
+          disableCache:
+            partialEnv.config.command === 'serve' &&
+            // eslint-disable-next-line eqeqeq
+            partialEnv.config.server.watch === null,
           legacyInconsistentCjsInterop: options.legacyInconsistentCjsInterop,
           finalizeBareSpecifier: !depsOptimizerEnabled
             ? undefined


### PR DESCRIPTION
### Description

requires https://github.com/rolldown/rolldown/pull/6763, https://github.com/oxc-project/oxc-resolver/issues/872
fixes https://github.com/vitejs/rolldown-vite/issues/466

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
