### PR TITLE
fix(optimizer): sync `optimizeDeps.rollupOptions` and `optimizeDeps.rolldownOptions`

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -754,6 +754,19 @@ describe('resolveConfig', () => {
 
     await resolveConfig({ root: './inc?ud#s*', customLogger: logger }, 'build')
   })
+
+  test('syncs `build.rollupOptions` and `build.rolldownOptions`', async () => {
+    const resolved = await resolveConfig({}, 'build')
+    expect(resolved.build!.rollupOptions).toStrictEqual(
+      resolved.build!.rolldownOptions,
+    )
+    expect(resolved.worker!.rollupOptions).toStrictEqual(
+      resolved.worker!.rolldownOptions,
+    )
+    expect(resolved.optimizeDeps!.rollupOptions).toStrictEqual(
+      resolved.optimizeDeps!.rolldownOptions,
+    )
+  })
 })
 
 test('config compat 1', async () => {


### PR DESCRIPTION
### Description

These should be synced but were not.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
