### PR TITLE
fix: set `legalComments: 'none'` to align with Vite

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -735,6 +735,7 @@ function resolveRolldownOptions(
         output.format === 'iife' ||
         (isSsrTargetWebworkerEnvironment &&
           (typeof input === 'string' || Object.keys(input).length === 1)),
+      legalComments: 'none',
       minify:
         options.minify === 'oxc'
           ? libOptions && (format === 'es' || format === 'esm')

--- a/playground/lib/vite.config.js
+++ b/playground/lib/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
     target: 'chrome46',
     rollupOptions: {
       output: {
+        legalComments: 'inline',
         banner: `/*!\nMayLib\n*/`,
       },
     },


### PR DESCRIPTION
legal comments are handled by `build.license` feature.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
