### PR TITLE
fix: esbuild plugin converter with empty JS files.

### DIFF
--- a/packages/vite/src/node/optimizer/pluginConverter.ts
+++ b/packages/vite/src/node/optimizer/pluginConverter.ts
@@ -275,7 +275,7 @@ function createLoadHandler(
     if (
       (result.warnings && result.warnings.length > 0) ||
       (result.watchDirs && result.watchDirs.length > 0) ||
-      !result.contents
+      result.contents == null
     ) {
       throw new Error('not implemented')
     }


### PR DESCRIPTION
When converting an esbuild plugin to a rolldown plugin, we check if the result of the plugin call is "empty". However, if a file is empty, it will throw a `not implemented` error even if there is nothing wrong with the plugin.

This fixes it to check whether the value is nullable, not if it is an empty string. As a result, rolldown-vite no longer throws during the dependency optimization step.

I tested this by applying this patch to an internal codebase and it no longer throws at this step. The file in question that is being loaded is a random transitive dependency that's empty. Please don't ask me why that's a thing: https://unpkg.com/@standard-schema/spec@1.0.0/dist/index.js