### PR TITLE
feat: deprecate `build.commonjsOptions`

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -201,6 +201,7 @@ export interface BuildEnvironmentOptions {
   rolldownOptions?: RolldownOptions
   /**
    * Options to pass on to `@rollup/plugin-commonjs`
+   * @deprecated This option is no-op and will be removed in future versions.
    */
   commonjsOptions?: RollupCommonJSOptions
   /**


### PR DESCRIPTION
This option is no-op as the commonjs plugin is not used by rolldown-vite.