### PR TITLE
docs: update why.md

### DIFF
--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -1,27 +1,27 @@
 # Why Vite
 
+Vite is the most popular JavaScript build tool because it solves modern JavaScript problems with new advancements in the ecosystem:
+
+1. Availability of native ES modules in the browser
+2. The rise of JavaScript tools written in native languages.
+
 ## The Problems
 
-Before ES modules were available in browsers, developers had no native mechanism for authoring JavaScript in a modularized fashion. This is why we are all familiar with the concept of "bundling": using tools that crawl, process and concatenate our source modules into files that can run in the browser.
+Before ES modules were available in browsers, developers lacked a native mechanism for authoring JavaScript in a modularized fashion. This is why we are all familiar with the concept of "bundling": using tools that crawl, process and concatenate our source modules into files that can run in the browser.
 
-Over time we have seen tools like [webpack](https://webpack.js.org/), [Rollup](https://rollupjs.org) and [Parcel](https://parceljs.org/), which greatly improved the development experience for frontend developers.
+Over time, bundlers like `webpack`, `Rollup` and `Parcel` emerged. JavaScript code can now live in separate files, which the bundler can make work.
 
-However, as we build more and more ambitious applications, the amount of JavaScript we are dealing with is also increasing dramatically. It is not uncommon for large scale projects to contain thousands of modules. We are starting to hit a performance bottleneck for JavaScript based tooling: it can often take an unreasonably long wait (sometimes up to minutes!) to spin up a dev server, and even with Hot Module Replacement (HMR), file edits can take a couple of seconds to be reflected in the browser. The slow feedback loop can greatly affect developers' productivity and happiness.
-
-Vite aims to address these issues by leveraging new advancements in the ecosystem: the availability of native ES modules in the browser, and the rise of JavaScript tools written in compile-to-native languages.
+However, as applications become more ambitious, the amount of JavaScript we are dealing with is also increasing dramatically. Large scale projects contains thousands of modules. Developers hit performance bottlenecks for JavaScript based tooling.
 
 ### Slow Server Start
 
-When cold-starting the dev server, a bundler-based build setup has to eagerly crawl and build your entire application before it can be served.
+As applications got larger, it could take an unreasonably long wait (sometimes up to minutes!) when cold-starting a dev server. The traditional bundler-based build setup has to eagerly crawl and build your entire application before it can be served.
 
 Vite improves the dev server start time by first dividing the modules in an application into two categories: **dependencies** and **source code**.
 
 - **Dependencies** are mostly plain JavaScript that do not change often during development. Some large dependencies (e.g. component libraries with hundreds of modules) are also quite expensive to process. Dependencies may also be shipped in various module formats (e.g. ESM or CommonJS).
-
-  Vite [pre-bundles dependencies](./dep-pre-bundling.md) using [esbuild](https://esbuild.github.io/). esbuild is written in Go and pre-bundles dependencies 10-100x faster than JavaScript-based bundlers.
-
+  Vite uses [Rolldown](https://rolldown.rs/), which is written in Rust, to [pre-bundle dependencies](/dep-pre-bundling.md). Previous versions of Vite (v7 and earlier) used `esbuild`.
 - **Source code** often contains non-plain JavaScript that needs transforming (e.g. JSX, CSS or Vue/Svelte components), and will be edited very often. Also, not all source code needs to be loaded at the same time (e.g. with route-based code-splitting).
-
   Vite serves source code over [native ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules). This is essentially letting the browser take over part of the job of a bundler: Vite only needs to transform and serve source code on demand, as the browser requests it. Code behind conditional dynamic imports is only processed if actually used on the current screen.
 
 <script setup>
@@ -41,21 +41,20 @@ In Vite, HMR is performed over native ESM. When a file is edited, Vite only need
 
 Vite also leverages HTTP headers to speed up full page reloads (again, let the browser do more work for us): source code module requests are made conditional via `304 Not Modified`, and dependency module requests are strongly cached via `Cache-Control: max-age=31536000,immutable` so they don't hit the server again once cached.
 
-Once you experience how fast Vite is, we highly doubt you'd be willing to put up with bundled development again.
+## Why Rolldown
 
-## Why Bundle for Production
+Vite previously relied on two bundlers to meet differing requirements for development and production builds:
 
-Even though native ESM is now widely supported, shipping unbundled ESM in production is still inefficient (even with HTTP/2) due to the additional network round trips caused by nested imports. To get the optimal loading performance in production, it is still better to bundle your code with tree-shaking, lazy-loading and common chunk splitting (for better caching).
+1. esbuild for fast compilation during development
+2. Rollup for bundling, chunking, and optimizing production builds
 
-Ensuring optimal output and behavioral consistency between the dev server and the production build isn't easy. This is why Vite ships with a pre-configured [build command](./build.md) that bakes in many [performance optimizations](./features.md#build-optimizations) out of the box.
+This approach lets Vite focus on developer experience and orchestration instead of reinventing parsing and bundling. However, maintaining two separate bundling pipelines introduced inconsistencies: separate transformation pipelines, different plugin systems and a growing amount of glue code to keep bundling behavior aligned between development and production.
 
-## Why Not Bundle with esbuild?
+To solve this, [**VoidZero team**](https://voidzero.dev/) has built **Rolldown**, the next-generation bundler with the goal to be used in Vite. It is designed for:
 
-While Vite leverages esbuild to [pre-bundle some dependencies in dev](./dep-pre-bundling.md), Vite does not use esbuild as a bundler for production builds.
-
-Vite's current plugin API isn't compatible with using `esbuild` as a bundler. In spite of `esbuild` being faster, Vite's adoption of Rollup's flexible plugin API and infrastructure heavily contributed to its success in the ecosystem. For the time being, we believe that Rollup offers a better performance-vs-flexibility tradeoff.
-
-Rollup has also been working on performance improvements, [switching its parser to SWC in v4](https://github.com/rollup/rollup/pull/5073). And there is an ongoing effort to build a Rust-port of Rollup called Rolldown. Once Rolldown is ready, it could replace both Rollup and esbuild in Vite, improving build performance significantly and removing inconsistencies between development and build. You can watch [Evan You's ViteConf 2023 keynote for more details](https://youtu.be/hrdwQHoAp0M).
+- **Performance**: Rolldown is written in Rust and operates at native speed. It matches esbuild’s performance level and is [**10–30× faster than Rollup**](https://github.com/rolldown/benchmarks).
+- **Compatibility**: Rolldown supports the same plugin API as Rollup and Vite. Most Vite plugins work out of the box with Vite 8.
+- **More Features**: Rolldown unlocks more advanced features for Vite, including full bundle mode, more flexible chunk split control, module-level persistent cache, Module Federation, and more.
 
 ## How Vite Relates to Other Unbundled Build Tools?
 


### PR DESCRIPTION
Updating why.md. https://github.com/vitejs/rolldown-vite/issues/535

Will need some guidance. The current version of why.md talks a lot about being unbundled. 

We are releasing Full Bundle Mode soon. Will this be default on so that everyone will eventually have bundled dev server? If so, then I'll need to make more updates to reflect it.